### PR TITLE
Fixes indoor check

### DIFF
--- a/src/game/GridMap.cpp
+++ b/src/game/GridMap.cpp
@@ -799,7 +799,7 @@ float TerrainInfo::GetHeight(float x, float y, float z, bool pUseVmaps, float ma
 
 inline bool IsOutdoorWMO(uint32 mogpFlags)
 {
-    return mogpFlags & 0x8008;
+    return mogpFlags & 0x8000;
 }
 
 bool TerrainInfo::IsOutdoors(float x, float y, float z) const


### PR DESCRIPTION
Fixes indoor check for Warsong flagroom, Alterac Valley cave entrance, Alterac Valley towers and others.

http://i54.tinypic.com/263c2kp.jpg

This leads to problem that players can already mount before the bg started (same for warsong).

If you want video proof (only TBC but I think works the same on Vanilla):
Horde: http://www.youtube.com/watch?v=IlaDEccU8E4
Alliance: http://www.youtube.com/watch?v=KZOU0AqK3pc

Needs to be tested thoroughly!
