### PR TITLE
Fixed a crash on closing mangosd.exe

### DIFF
--- a/src/game/BattleGround.cpp
+++ b/src/game/BattleGround.cpp
@@ -206,7 +206,7 @@ BattleGround::BattleGround()
     m_Status            = STATUS_NONE;
     m_ClientInstanceID  = 0;
     m_EndTime           = 0;
-    m_BracketId         = MAX_BATTLEGROUND_BRACKETS;        // use as mark bg template
+    m_BracketId         = BG_BRACKET_ID_TEMPLATE;        // use as mark bg template
     m_InvitedAlliance   = 0;
     m_InvitedHorde      = 0;
     m_Winner            = 2;
@@ -271,8 +271,10 @@ BattleGround::~BattleGround()
         DelObject(i);
 
     sBattleGroundMgr.RemoveBattleGround(GetInstanceID(), GetTypeID());
-	// if its not template bg
-	if(GetBracketId()!=MAX_BATTLEGROUND_BRACKETS)
+	
+	// skip template bgs as they were never added to visible bg list
+	BattleGroundBracketId bracketId = GetBracketId();
+	if (bracketId != BG_BRACKET_ID_TEMPLATE)
 		sBattleGroundMgr.DeleteClientVisibleInstanceId(GetTypeID(), GetBracketId(), GetClientInstanceID());
 
     // unload map

--- a/src/game/BattleGround.cpp
+++ b/src/game/BattleGround.cpp
@@ -271,7 +271,9 @@ BattleGround::~BattleGround()
         DelObject(i);
 
     sBattleGroundMgr.RemoveBattleGround(GetInstanceID(), GetTypeID());
-    sBattleGroundMgr.DeleteClientVisibleInstanceId(GetTypeID(), GetBracketId(), GetClientInstanceID());
+	// if its not template bg
+	if(GetBracketId()!=MAX_BATTLEGROUND_BRACKETS)
+		sBattleGroundMgr.DeleteClientVisibleInstanceId(GetTypeID(), GetBracketId(), GetClientInstanceID());
 
     // unload map
     // map can be null at bg destruction

--- a/src/game/BattleGround.h
+++ b/src/game/BattleGround.h
@@ -144,12 +144,14 @@ enum BattleGroundQueueTypeId
 };
 #define MAX_BATTLEGROUND_QUEUE_TYPES 4
 
-enum BattleGroundBracketId                                  // bracketId for level ranges
+enum BattleGroundBracketId                                 // bracketId for level ranges
 {
-    BG_BRACKET_ID_FIRST          = 0,                       // brackets start from specific BG min level and each include 10 levels range
-    BG_BRACKET_ID_LAST           = 5,                       // so for start level 10 will be 10-19, 20-29, ...  all greater max bg level included in last bracket
+	BG_BRACKET_ID_TEMPLATE      = -1,                      // used to mark bg as template
 
-    MAX_BATTLEGROUND_BRACKETS    = 6                        // used as one from values, so in enum
+    BG_BRACKET_ID_FIRST         = 0,                       // brackets start from specific BG min level and each include 10 levels range
+    BG_BRACKET_ID_LAST          = 5,                       // so for start level 10 will be 10-19, 20-29, ...  all greater max bg level included in last bracket
+
+	MAX_BATTLEGROUND_BRACKETS	= BG_BRACKET_ID_LAST - BG_BRACKET_ID_FIRST + 1
 };
 
 enum ScoreType

--- a/src/game/BattleGround.h
+++ b/src/game/BattleGround.h
@@ -150,9 +150,8 @@ enum BattleGroundBracketId                                 // bracketId for leve
 
     BG_BRACKET_ID_FIRST         = 0,                       // brackets start from specific BG min level and each include 10 levels range
     BG_BRACKET_ID_LAST          = 5,                       // so for start level 10 will be 10-19, 20-29, ...  all greater max bg level included in last bracket
-
-	MAX_BATTLEGROUND_BRACKETS	= BG_BRACKET_ID_LAST - BG_BRACKET_ID_FIRST + 1
 };
+#define MAX_BATTLEGROUND_BRACKETS 6
 
 enum ScoreType
 {


### PR DESCRIPTION
Crash log:

<pre>
Revision: * * 1809 *
Date 8:11:2011. Time 17:11 
//=====================================================
*** Hardware ***
Processor: Intel(R) Celeron(R) M CPU        520  @ 1.60GHz
Number Of Processors: 1
Physical Memory: 2087024 KB (Available: 1133052 KB)
Commit Charge Limit: 2701204 KB

*** Operation System ***
Microsoft Windows XP Professional Service Pack 3 (Version 5.1, Build 2600)

//=====================================================
Exception code: C0000005 ACCESS_VIOLATION
Fault address:  0090F629 02:000BB629 D:\MaNGOS\zero_dev\Mangos_Server\bin\Win32_Debug\mangosd.exe

Registers:
EAX:E5E5E5E9
EBX:020EB150
ECX:E5E5E5E5
EDX:78CC5600
ESI:02F9FE70
EDI:02F9FD04
CS:EIP:001B:0090F629
SS:ESP:0023:02F9FCBC  EBP:02F9FD10
DS:0023  ES:0023  FS:003B  GS:0000
Flags:00010246

Call stack:
Address   Frame     Function      SourceFile
0090F629  00000000  
</pre>


With some debug magic i found that BattleGroundMng tries to erase some not existing data.
<dt>New problem</dt>

After shutdown command (or restart), mangosd.exe proccess freezes (he still works but eats all CPU time) and not exiting by himself (if i click "close" button it closes process). Debug shows that it start freezing after "exit(code)" function (after executing main).
