### PR TITLE
2 backports from mangos-one and one spell fix

### DIFF
--- a/src/game/CreatureEventAIMgr.cpp
+++ b/src/game/CreatureEventAIMgr.cpp
@@ -819,6 +819,20 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
 
         delete result;
 
+        // post check
+        for (uint32 i = 1; i < sCreatureStorage.MaxEntry; ++i)
+        {
+            if (CreatureInfo const* cInfo = sCreatureStorage.LookupEntry<CreatureInfo>(i))
+            {
+                bool ainame = strcmp(cInfo->AIName, "EventAI") == 0;
+                bool hasevent = m_CreatureEventAI_Event_Map.find(i) != m_CreatureEventAI_Event_Map.end();
+                if (ainame && !hasevent)
+                    sLog.outErrorDb("CreatureEventAI: EventAI not has script for creature entry (%u), but AIName = '%s'.", i, cInfo->AIName);
+                else if (!ainame && hasevent)
+                    sLog.outErrorDb("CreatureEventAI: EventAI has script for creature entry (%u), but AIName = '%s' instead 'EventAI'.", i, cInfo->AIName);
+            }
+        }
+
         CheckUnusedAITexts();
         CheckUnusedAISummons();
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -1441,6 +1441,7 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                 case 802:                                   // Mutate Bug
                 case 804:                                   // Explode Bug
                 case 23138:                                 // Gate of Shazzrah
+                case 24781:                                 // Dream Fog
                 case 28560:                                 // Summon Blizzard
                     unMaxTargets = 1;
                     break;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -929,8 +929,6 @@ void Aura::TriggerSpell()
 //                    case 24379: break;
 //                    // Happy Pet
 //                    case 24716: break;
-//                    // Dream Fog
-//                    case 24780: break;
 //                    // Cannon Prep
 //                    case 24832: break;
                     case 24834:                             // Shadow Bolt Whirl

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -934,14 +934,14 @@ void Aura::TriggerSpell()
                     case 24834:                             // Shadow Bolt Whirl
                     {
                         uint32 spellForTick[8] = { 24820, 24821, 24822, 24823, 24835, 24836, 24837, 24838 };
-                        uint32 tick = GetAuraTicks();
+                        uint32 tick = GetAuraTicks() % 8;
                         if (tick < 8)
                         {
                             trigger_spell_id = spellForTick[tick];
 
                             // casted in left/right (but triggered spell have wide forward cone)
                             float forward = target->GetOrientation();
-                            float angle = target->GetOrientation() + (tick % 2 == 0 ? M_PI_F / 2 : - M_PI_F / 2);
+                            float angle = target->GetOrientation() - (tick * 2 * M_PI_F / 8);
                             target->SetOrientation(angle);
                             triggerTarget->CastSpell(triggerTarget, trigger_spell_id, true, NULL, this, casterGUID);
                             target->SetOrientation(forward);

--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -828,6 +828,14 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     m_caster->CastSpell(m_caster, 23782, true);
                     m_caster->CastSpell(m_caster, 23783, true);
                     return;
+                case 24781:                                 // Dream Fog
+                {
+                    if (m_caster->GetTypeId() != TYPEID_UNIT || !unitTarget)
+                        return;
+                    // TODO Note: Should actually not only AttackStart, but fixate on the target
+                    ((Creature*)m_caster)->AI()->AttackStart(unitTarget);
+                    return;
+                }
                 case 24930:                                 // Hallow's End Treat
                 {
                     uint32 spell_id = 0;


### PR DESCRIPTION
- add spell "Dream Fog" for Emerald Dragon (need more fixing script/DB side)
- fix spell "Shadow Bolt Whirl" for Lethon (should be ported to other cores)
- Improve eventAI
